### PR TITLE
translate "cd:" to "cdda://" only for playback

### DIFF
--- a/mopidy_cd/backend.py
+++ b/mopidy_cd/backend.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class CdBackend(pykka.ThreadingActor, backend.Backend):
-    uri_schemes = ['cd','cdda']
+    uri_schemes = ['cd']
 
     def __init__(self, config, audio):
         super(CdBackend, self).__init__()
@@ -42,7 +42,7 @@ class CdLibrary(backend.LibraryProvider):
         i=int(uri.lstrip("cd:/"))
         logger.debug('Cdrom: track %s selected',i)
         (number,name,duration) = self.backend.cdrom.tracks[i]
-        return [Track(uri='cdda://%d' % number,
+        return [Track(uri=uri,
                       name=name,
                       length=int(duration)*1000)]
         
@@ -51,3 +51,6 @@ class CdPlaybackProvider(backend.PlaybackProvider):
     def change_track(self, track):
         logger.debug('Cdrom: playing track %s', track)
         return super(CdPlaybackProvider, self).change_track(track)
+
+    def translate_uri(self, uri):
+        return uri.replace('cd:/','cdda://')


### PR DESCRIPTION
Currently there are two URI schemes used for Tracks.
This leads to problems when using the mpd frontend (with mpdroid at least) as line 42 does not account for one of them.
Instead of fixing the symptom this commit get's rid of the cdda:// scheme for Tracks and only uses it for playback.