### PR TITLE
Remove unused imports

### DIFF
--- a/mopidy_cd/__init__.py
+++ b/mopidy_cd/__init__.py
@@ -3,17 +3,14 @@ from __future__ import unicode_literals
 import logging
 import os
 
-import pygst
-pygst.require('0.10')
-import gobject
-
-from mopidy import config, exceptions, ext
+from mopidy import config, ext
 
 
 __version__ = '0.1'
 
 # If you need to log, use loggers named after the current Python module
 logger = logging.getLogger(__name__)
+
 
 class Extension(ext.Extension):
 


### PR DESCRIPTION
pygst is not used by mopidy-cd so it should not be imported. It adds the (unsatisfiable in my buildroot environment) dependency, so it should be avoided.

I also removed the unused mopidy.exception import.