### PR TITLE
fix: Fixed modern python Mapping import

### DIFF
--- a/mopidy_cd/cdrom.py
+++ b/mopidy_cd/cdrom.py
@@ -5,7 +5,8 @@ import math
 
 import musicbrainzngs
 
-from collections import Mapping, namedtuple
+from collections.abc import Mapping
+from collections import namedtuple
 from datetime import timedelta
 
 from mopidy.audio.scan import Scanner

--- a/mopidy_cd/cdrom.py
+++ b/mopidy_cd/cdrom.py
@@ -5,7 +5,10 @@ import math
 
 import musicbrainzngs
 
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping  # Backwards compatibility
 from collections import namedtuple
 from datetime import timedelta
 


### PR DESCRIPTION
Closes #21

https://github.com/antosart/mopidy-cd/issues/21